### PR TITLE
fix: rename wrapper shebang

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -431,7 +431,7 @@ async function initCCProfile(): Promise<void> {
     }
 
     // Create wrapper script
-    const wrapperContent = `#!/bin/bash
+    const wrapperContent = `#!/usr/bin/env bash
 # cc-profile wrapper for Claude Code
 
 # Parse cc-profile specific arguments


### PR DESCRIPTION
Renamed the wrapper shebang to be compatible with all distros (namely nixos)